### PR TITLE
Add timeline module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,10 @@ clean:
 	rm -rf build
 
 .PHONY: build run clean check-tools
+
+
+# Start the official visual runtime
+ui-demo:
+	cd ui_runtime && ./start_demo.sh
+
+.PHONY: ui-demo

--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ Composto por:
 - 0 dependências externas
 
 ---
+## 🧠 UI Runtime
+
+O diretório `ui_runtime/` é o motor visual oficial do LogLineOS. Ele executa e renderiza contratos `.logline` diretamente no navegador de forma canônica.
+
+Para testar:
+
+```bash
+cd ui_runtime && ./start_demo.sh
+```
+
+Edite os contratos visuais e recarregue a página para vê-los através do `runtime.mjs`. Este runtime será utilizado por aplicações do ecossistema, como `minicontratos/` e `voulezvous.tv`.
+
+## 🕒 Timeline
+
+O diretório `timeline/` guarda a linha do tempo factual do sistema. Cada instância registra spans em arquivos `.jsonl` e pode sincronizar com PostgreSQL, mas seu uso é opcional e modular. Ele pode ser removido ou movido para outro repositório sem afetar o restante do LogLineOS.
 
 ## 📬 Contato
 
@@ -199,3 +214,4 @@ Try the `kernelization_test.logline` contract to compile and run a WASM module:
 go build
 ./motorcodex examples/kernelization_test.logline
 ```
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,8 @@ While the current prototype is written in Go, other architectures could improve 
    - Allows running the same engine in browsers and servers.
 
 Each approach has trade-offs in complexity and performance. See the main code for the reference Go implementation.
+The repository also ships with `ui_runtime/`, a minimal browser engine to render LogLine contracts.
+The `timeline/` module records spans in `.jsonl` files and can optionally sync to PostgreSQL.
 
 
 ## Further Ideas

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -23,3 +23,12 @@ You can run it with:
 ```bash
 make run workflow=examples/example.logline
 ```
+The `ui_runtime/` directory contains a standalone browser runtime for visual contracts. You can try it with:
+
+```bash
+cd ui_runtime && ./start_demo.sh
+```
+
+Then open `http://localhost:8000/index.html?file=../examples/ui_runtime_demo.logline` to render the example `examples/ui_runtime_demo.logline`.
+
+Span history can be persisted by instantiating the `timeline/` module. Use `timeline_instance.logline` to define where `.jsonl` files live and optionally sync them to Postgres.

--- a/docs/PROMPTPAD_VISION.md
+++ b/docs/PROMPTPAD_VISION.md
@@ -2,6 +2,8 @@
 
 PromptPad is the conceptual front-end for interacting with LogLine workflows. It unifies command execution, log viewing, and AI assistance in a single interface.
 
+This interface is powered by the `ui_runtime/` engine, which renders `.logline` contracts directly in the browser.
+
 **Key concepts**
 
 1. **Unified Input** – one text box accepts both natural language queries and workflow commands.

--- a/examples/ui_runtime_demo.logline
+++ b/examples/ui_runtime_demo.logline
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "span",
+    "component": "text_block",
+    "content": "Hello from the UI Runtime!"
+  }
+]

--- a/timeline/LICENSE.md
+++ b/timeline/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 LogLine Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/timeline/README.md
+++ b/timeline/README.md
@@ -1,0 +1,16 @@
+# Timeline Module
+
+This directory stores an audit-ready timeline of spans for LogLineOS. Each instance records events in `.jsonl` files and can optionally synchronize with PostgreSQL.
+
+## Usage
+
+1. Register the instance via `timeline_instance.logline`.
+2. Append spans with `write_span.logline`.
+3. Read ranges using `read_span_range.logline` or filter with `query_by_type.logline`.
+4. Rotate files with `rotate_jsonl_file.logline` when they exceed the configured size.
+5. Call `flush_spans.logline` to force writes to disk.
+6. Run `sync_to_postgres.logline` for hybrid storage.
+
+To enable PostgreSQL support, run `setup_postgres_timeline.sh` to create the required tables.
+
+This module is optional and can be extracted to a separate repository without affecting the rest of LogLineOS.

--- a/timeline/flush_spans.logline
+++ b/timeline/flush_spans.logline
@@ -1,0 +1,2 @@
+- type: flush_file
+  file: "{{timeline.location}}{{tenant_id}}_spans.jsonl"

--- a/timeline/query_by_type.logline
+++ b/timeline/query_by_type.logline
@@ -1,0 +1,2 @@
+- type: postgres_query
+  query: "SELECT * FROM spans WHERE tenant_id = '{{tenant_id}}' AND type = '{{span_type}}' ORDER BY created_at DESC LIMIT {{limit}}"

--- a/timeline/read_span_range.logline
+++ b/timeline/read_span_range.logline
@@ -1,0 +1,4 @@
+- type: read_jsonl_range
+  file: "{{timeline.location}}{{tenant_id}}_spans.jsonl"
+  start: "{{start_offset}}"
+  end: "{{end_offset}}"

--- a/timeline/rotate_jsonl_file.logline
+++ b/timeline/rotate_jsonl_file.logline
@@ -1,0 +1,6 @@
+- type: check_size
+  file: "{{timeline.location}}{{tenant_id}}_spans.jsonl"
+  max_mb: "{{timeline.max_file_size_mb}}"
+  then:
+    - type: rotate_file
+      file: "{{timeline.location}}{{tenant_id}}_spans.jsonl"

--- a/timeline/setup_postgres_timeline.sh
+++ b/timeline/setup_postgres_timeline.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+psql "$POSTGRES_URL" <<SQL
+CREATE TABLE IF NOT EXISTS spans (
+    id SERIAL PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+SQL

--- a/timeline/sync_to_postgres.logline
+++ b/timeline/sync_to_postgres.logline
@@ -1,0 +1,4 @@
+- type: postgres_copy
+  source: "{{timeline.location}}{{tenant_id}}_spans.jsonl"
+  table: spans
+  tenant_id: "{{tenant_id}}"

--- a/timeline/timeline_instance.logline
+++ b/timeline/timeline_instance.logline
@@ -1,0 +1,12 @@
+id: timeline:primary
+type: contract
+who: system:kernel
+did: register_timeline_instance
+payload:
+  description: Linha do tempo padrão do sistema institucional
+  tenant_id: loglinefoundation
+  storage_mode: jsonl+postgres_fallback
+  max_file_size_mb: 100
+  flush_policy: on_interval
+  location: ./data/spans/
+  backup_policy: hourly

--- a/timeline/write_span.logline
+++ b/timeline/write_span.logline
@@ -1,0 +1,4 @@
+- type: append_jsonl
+  file: "{{timeline.location}}{{tenant_id}}_spans.jsonl"
+  span: "{{input_span}}"
+  flush: false


### PR DESCRIPTION
## Summary
- add optional `timeline/` directory for audit-ready spans
- mention new timeline module in README and docs
- explain how to persist spans in examples docs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_687115985bcc8328861e86dfe5324143